### PR TITLE
Fix: classes for indicators.

### DIFF
--- a/src/app/components/password-strength/password-strength.component.html
+++ b/src/app/components/password-strength/password-strength.component.html
@@ -28,3 +28,4 @@
     </div>
   </div>
 </div>
+<ng-container class="w-1/3"></ng-container>


### PR DESCRIPTION
tailwind adds into budle only used classes, so when switching the number of indicators, one class is not in the bundle.